### PR TITLE
Add spam protection option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,10 @@ INC_FLAGS := $(addprefix -I,$(INC_DIRS))
 
 CPPFLAGS ?= $(INC_FLAGS) -MMD -MP -Wall
 LDLIBS ?= -lm
+LDFLAGS += -fPIC
+ifeq ($(FFBTOOLS_EFFECT_HISTORY_EXPONENTIAL_GROWTH),yes)
+	CFLAGS += -DFFBTOOLS_EFFECT_HISTORY_EXPONENTIAL_GROWTH
+endif
 
 all: $(BUILD_DIR) \
 	$(BUILD_DIR)/libffbwrapper-i386.so \
@@ -39,10 +43,10 @@ $(BUILD_DIR):
 	mkdir -p $(BUILD_DIR)
 
 $(BUILD_DIR)/libffbwrapper-i386.so: $(SRC_DIR)/ffbwrapper.c
-	$(CC) $(CPPFLAGS) $(CFLAGS) -m32 -fPIC -shared $< -o $@ -ldl
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -m32 -shared $< -o $@ -ldl
 
 $(BUILD_DIR)/libffbwrapper-x86_64.so: $(SRC_DIR)/ffbwrapper.c
-	$(CC) $(CPPFLAGS) $(CFLAGS) -fPIC -shared $< -o $@ -ldl
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -shared $< -o $@ -ldl
 
 $(BUILD_DIR)/ffbplay: $(BUILD_DIR)/ffbplay.o
 	$(CC) $(LDFLAGS) -o $@ $< $(LDLIBS)

--- a/bin/ffbwrap
+++ b/bin/ffbwrap
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-OPTIONS=$(getopt --long 'logger:,update-fix,direction-fix,features-hack,force-inversion,ignore-set-gain,offset-fix' -n "$0" -- "" "$@")
+OPTIONS=$(getopt --long 'logger:,update-fix,direction-fix,features-hack,force-inversion,ignore-set-gain,offset-fix,spam-protection' -n "$0" -- "" "$@")
 
 if [ $? -ne 0 ]; then
 	exit 1
@@ -78,6 +78,11 @@ while true; do
             shift
             continue
             ;;
+        '--spam-protection')
+            FFBTOOLS_SPAM_PROTECTION=1
+            shift
+            continue
+            ;;
         '--')
             shift
             break
@@ -104,6 +109,6 @@ fi
 
 FFBTOOLS_DEVICE_NAME="$(eval $(udevadm info -q property -x "${DEVICE_FILE}") && echo "${ID_VENDOR} ${ID_MODEL//_/ }")"
 
-export LD_PRELOAD FFBTOOLS_DEVICE_NAME FFBTOOLS_DEV_MAJOR FFBTOOLS_DEV_MINOR FFBTOOLS_LOGGER FFBTOOLS_LOG_FILE FFBTOOLS_UPDATE_FIX FFBTOOLS_DIRECTION_FIX FFBTOOLS_FEATURES_HACK FFBTOOLS_FORCE_INVERSION FFBTOOLS_IGNORE_SET_GAIN FFBTOOLS_OFFSET_FIX
+export LD_PRELOAD FFBTOOLS_DEVICE_NAME FFBTOOLS_DEV_MAJOR FFBTOOLS_DEV_MINOR FFBTOOLS_LOGGER FFBTOOLS_LOG_FILE FFBTOOLS_UPDATE_FIX FFBTOOLS_DIRECTION_FIX FFBTOOLS_FEATURES_HACK FFBTOOLS_FORCE_INVERSION FFBTOOLS_IGNORE_SET_GAIN FFBTOOLS_OFFSET_FIX FFBTOOLS_SPAM_PROTECTION
 
 "${COMMAND}" "$@"

--- a/docs/ffbwrap.md
+++ b/docs/ffbwrap.md
@@ -36,6 +36,8 @@ One or more of the following options can be used:
   `--offset-fix`: Proton sets `offset` and `phase` to incorrect values. This
   option fixes it.
 
+  `--spam-protection`: Ignore any uploads that push the same parameters repeatedly to the same effect ID. Use this if you see kernel logs messages indicating that the force feedback queue is piling up.
+
 ## Examples
 
 Log calls to a file:

--- a/src/ffbwrapper.c
+++ b/src/ffbwrapper.c
@@ -180,15 +180,27 @@ static inline void init_effects_history(unsigned int count)
         count = DEFAULT_EFFECT_HISTORY_SIZE;
     }
     if (count > effects_history_len || effects_history == NULL) {
-        struct ff_effect *new_effects_history = calloc(count, sizeof(struct ff_effect));
-        memset(new_effects_history, 0, count * sizeof(struct ff_effect));
-        if (effects_history != NULL) {
-            memcpy(new_effects_history, effects_history, count * effects_history_len);
-            free(effects_history);
-            effects_history = NULL;
+#ifdef FFBTOOLS_EFFECT_HISTORY_EXPONENTIAL_GROWTH
+        size_t new_effects_history_len = effects_history_len;
+        if (new_effects_history_len == 0) {
+            new_effects_history_len = DEFAULT_EFFECT_HISTORY_SIZE;
         }
-        effects_history = new_effects_history;
-        effects_history_len = count;
+        while (count > new_effects_history_len) {
+            new_effects_history_len *= 2;
+        }
+        count = (unsigned int)new_effects_history_len;
+#endif /* defined(FFBTOOLS_EFFECT_HISTORY_EXPONENTIAL_GROWTH */
+        if (effects_history != NULL) {
+            effects_history = reallocarray(effects_history, sizeof(struct ff_effect), count);
+            effects_history_len = count;
+        } else {
+            struct ff_effect *new_effects_history = calloc(count, sizeof(struct ff_effect));
+            memset(new_effects_history, 0, count * sizeof(struct ff_effect));
+            if (new_effects_history != NULL) {
+                effects_history = new_effects_history;
+                effects_history_len = count;
+            }
+        }
     }
 }
 

--- a/src/ffbwrapper.c
+++ b/src/ffbwrapper.c
@@ -170,7 +170,9 @@ static int checkDescriptor(int fd)
     return 0;
 }
 
+#ifndef DEFAULT_EFFECT_HISTORY_SIZE
 #define DEFAULT_EFFECT_HISTORY_SIZE (512)
+#endif /* !defined(DEFAULT_EFFECT_HISTORY_SIZE */
 static struct ff_effect *effects_history = NULL;
 static size_t effects_history_len = 0;
 


### PR DESCRIPTION
This pull request adds a `--spam-protection` option to `ffbwrap`, that causes the `ioctl` to ignore any requests to repeatedly update the same effect ID with the same parameters.

Games like Assetto Corsa Competizione do this while the game is paused, spamming updates when the first one would suffice.

The result is that the queue on the kernel side grows too large, and events begin dropping. This tweak can fix that for those titles.

Related issues:
* ValveSoftware/Proton#3246
* ValveSoftware/Proton#1420

FWIW, with this tweak, I was able to play for hours with my G920 with no issues, whereas before I had to be *ultra* careful not to ever pause the game for more than a few seconds, so that events would not be dropped.

While the real issue might be on the proton side, this is still a useful tweak for this temporary stop-gap repo, as that's what this is all about.

Thanks for the time,
Matt