### PR TITLE
Add support for force feedback devices that take replay length into account

### DIFF
--- a/src/ffbwrapper.c
+++ b/src/ffbwrapper.c
@@ -189,7 +189,12 @@ int ioctl(int fd, unsigned long request, char *argp)
             break;
         case ioctlRequestCode(EVIOCSFF):
             effect = (struct ff_effect*) argp;
-            effect->replay.length = 0x4e20;
+
+            /* don't know if length of 0 is intentional or not, but I'll assume
+             * it wasn't. */
+            if(effect->replay.length == 0){
+                effect->replay.length = 0x4e20;
+            }
             char *type = "UNKNOWN";
             switch (effect->type) {
                 case FF_RUMBLE:

--- a/src/ffbwrapper.c
+++ b/src/ffbwrapper.c
@@ -189,7 +189,7 @@ int ioctl(int fd, unsigned long request, char *argp)
             break;
         case ioctlRequestCode(EVIOCSFF):
             effect = (struct ff_effect*) argp;
-
+            effect->replay.length = 0x4e20;
             char *type = "UNKNOWN";
             switch (effect->type) {
                 case FF_RUMBLE:


### PR DESCRIPTION
Hi, I'm writing a driver for the Thrustmaster T300RS wheel, and I noticed ffbwrapper wan't working out for me. Turns out, all force feedback effect replay lengths were 0 for some reason.

This is a quick fix that I came up with, and now my wheel works smooth as butter.