### PR TITLE
Add workaround for full cmd queue issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 #
 # Makefile for ffbtools
-# 
+#
 # Copyright 2019 Bernat Arlandis <bernat@hotmail.com>
 #
 # This file is part of ffbtools.
@@ -39,10 +39,10 @@ $(BUILD_DIR):
 	mkdir -p $(BUILD_DIR)
 
 $(BUILD_DIR)/libffbwrapper-i386.so: $(SRC_DIR)/ffbwrapper.c
-	$(CC) $(CPPFLAGS) $(CFLAGS) -m32 -fPIC -shared $< -o $@ -ldl
+	$(CC) $(CPPFLAGS) $(CFLAGS) -m32 -fPIC -shared $< -o $@ -lrt -ldl
 
 $(BUILD_DIR)/libffbwrapper-x86_64.so: $(SRC_DIR)/ffbwrapper.c
-	$(CC) $(CPPFLAGS) $(CFLAGS) -fPIC -shared $< -o $@ -ldl
+	$(CC) $(CPPFLAGS) $(CFLAGS) -fPIC -shared $< -o $@ -lrt -ldl
 
 $(BUILD_DIR)/ffbplay: $(BUILD_DIR)/ffbplay.o
 	$(CC) $(LDFLAGS) -o $@ $< $(LDLIBS)

--- a/bin/ffbwrap
+++ b/bin/ffbwrap
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # Runs a command preloading libffbwrapper
-# 
+#
 # Copyright 2019 Bernat Arlandis <bernat@hotmail.com>
 #
 # This file is part of ffbtools.
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-OPTIONS=$(getopt --long 'logger:,update-fix,direction-fix,features-hack,force-inversion,ignore-set-gain,offset-fix' -n "$0" -- "" "$@")
+OPTIONS=$(getopt --long 'logger:,update-fix,direction-fix,features-hack,force-inversion,ignore-set-gain,offset-fix,throttling' -n "$0" -- "" "$@")
 
 if [ $? -ne 0 ]; then
 	exit 1
@@ -78,6 +78,11 @@ while true; do
             shift
             continue
             ;;
+        '--throttling')
+            FFBTOOLS_THROTTLING=1
+            shift
+            continue
+            ;;
         '--')
             shift
             break
@@ -98,12 +103,12 @@ COMMAND="$1"
 shift
 
 if [ -z "${FFBTOOLS_DEV_MAJOR}" -o -z "${FFBTOOLS_DEV_MINOR}" -o -z "${COMMAND}" ]; then
-    echo "Usage: $0 [--logger=logfile] [--update-fix] [--direction-fix] [--features-hack] [--force-inversion] [--ignore-set-gain] [--offset-fix] <device> -- <command>"
+    echo "Usage: $0 [--logger=logfile] [--update-fix] [--direction-fix] [--features-hack] [--force-inversion] [--ignore-set-gain] [--offset-fix] [--throttling] <device> -- <command>"
     exit 1
 fi
 
 FFBTOOLS_DEVICE_NAME="$(eval $(udevadm info -q property -x "${DEVICE_FILE}") && echo "${ID_VENDOR} ${ID_MODEL//_/ }")"
 
-export LD_PRELOAD FFBTOOLS_DEVICE_NAME FFBTOOLS_DEV_MAJOR FFBTOOLS_DEV_MINOR FFBTOOLS_LOGGER FFBTOOLS_LOG_FILE FFBTOOLS_UPDATE_FIX FFBTOOLS_DIRECTION_FIX FFBTOOLS_FEATURES_HACK FFBTOOLS_FORCE_INVERSION FFBTOOLS_IGNORE_SET_GAIN FFBTOOLS_OFFSET_FIX
+export LD_PRELOAD FFBTOOLS_DEVICE_NAME FFBTOOLS_DEV_MAJOR FFBTOOLS_DEV_MINOR FFBTOOLS_LOGGER FFBTOOLS_LOG_FILE FFBTOOLS_UPDATE_FIX FFBTOOLS_DIRECTION_FIX FFBTOOLS_FEATURES_HACK FFBTOOLS_FORCE_INVERSION FFBTOOLS_IGNORE_SET_GAIN FFBTOOLS_OFFSET_FIX FFBTOOLS_THROTTLING
 
 "${COMMAND}" "$@"

--- a/docs/ffbwrap.md
+++ b/docs/ffbwrap.md
@@ -36,6 +36,10 @@ One or more of the following options can be used:
   `--offset-fix`: Proton sets `offset` and `phase` to incorrect values. This
   option fixes it.
 
+  `--throttling`: Puts a limit to the number of effect commands that can be
+  sent to avoid filling the command queue of the device. It helps with issues
+  like effect lag and "full queue" messages in the log.
+
 ## Examples
 
 Log calls to a file:


### PR DESCRIPTION
I've added a throttling option to try to fix an issue that can happen with the
Logitech in-kernel drivers when effect commands are sent faster than the wheel
can process.

I've decided to implement this after PR #17 by @mcoffin. This approach is more
generic and it's based on the way I solved the issue in
https://github.com/berarma/new-lg4ff.

The time period for command flushing is set to 3ms.

I would need someone to test that it actually solves the issue.
