### PR TITLE
throttling: Make throttling interval configurable

### DIFF
--- a/src/ffbwrapper.c
+++ b/src/ffbwrapper.c
@@ -422,12 +422,16 @@ int ioctl(int fd, unsigned long request, char *argp)
             }
 
             if (enable_throttling && effect->id != -1) {
-                throttled = true;
-                pthread_spin_lock(&pending_effects_lock);
-                memcpy((char*) &pending_effects[effect->id], (char*) effect, sizeof(struct ff_effect));
-                pending_fd[effect->id] = fd;
-                effect_is_pending[effect->id] = 1;
-                pthread_spin_unlock(&pending_effects_lock);
+                if (effect->id > FFBTOOLS_MAX_EFFECT_ID) {
+                    report("! cannot throttle id:%d > %d", effect->id, FFBTOOLS_MAX_EFFECT_ID);
+                } else {
+                    throttled = true;
+                    pthread_spin_lock(&pending_effects_lock);
+                    memcpy((char*) &pending_effects[effect->id], (char*) effect, sizeof(struct ff_effect));
+                    pending_fd[effect->id] = fd;
+                    effect_is_pending[effect->id] = 1;
+                    pthread_spin_unlock(&pending_effects_lock);
+                }
             }
 
             break;

--- a/src/ffbwrapper.c
+++ b/src/ffbwrapper.c
@@ -69,7 +69,7 @@ static int enable_throttling = 0;
 static FILE *log_file = NULL;
 static char report_string[1024];
 static short last_effect_used = 16;
-static char effect_is_pending[FFBTOOLS_THROTTLE_BUFFER_SIZE] = {0};
+static bool effect_is_pending[FFBTOOLS_THROTTLE_BUFFER_SIZE] = {false};
 static int pending_fd[FFBTOOLS_THROTTLE_BUFFER_SIZE];
 static struct ff_effect pending_effects[FFBTOOLS_THROTTLE_BUFFER_SIZE];
 static struct ff_effect tmp_effect;
@@ -106,7 +106,7 @@ static void send_effect(int id)
 
     pthread_spin_lock(&pending_effects_lock);
     if (effect_is_pending[id]) {
-        effect_is_pending[id] = 0;
+        effect_is_pending[id] = false;
         fd = pending_fd[id];
         memcpy((char*) &tmp_effect, (char*) &pending_effects[id], sizeof(struct ff_effect));
         pthread_spin_unlock(&pending_effects_lock);
@@ -429,7 +429,7 @@ int ioctl(int fd, unsigned long request, char *argp)
                     pthread_spin_lock(&pending_effects_lock);
                     memcpy((char*) &pending_effects[effect->id], (char*) effect, sizeof(struct ff_effect));
                     pending_fd[effect->id] = fd;
-                    effect_is_pending[effect->id] = 1;
+                    effect_is_pending[effect->id] = true;
                     pthread_spin_unlock(&pending_effects_lock);
                 }
             }

--- a/src/ffbwrapper.c
+++ b/src/ffbwrapper.c
@@ -230,11 +230,11 @@ static void init()
         report("# DEVICE_NAME=%s, UPDATE_FIX=%d, "
                 "DIRECTION_FIX=%d, FEATURES_HACK=%d, "
                 "FORCE_INVERSION=%d, IGNORE_SET_GAIN=%d, OFFSET_FIX=%d, "
-                "THROTTLING=%d",
+                "THROTTLING=%s",
                 getenv("FFBTOOLS_DEVICE_NAME"), enable_update_fix,
                 enable_direction_fix, enable_features_hack,
                 enable_force_inversion, ignore_set_gain, enable_offset_fix,
-                enable_throttling);
+                str_throttling == NULL ? "0" : str_throttling);
     }
 }
 

--- a/src/ffbwrapper.c
+++ b/src/ffbwrapper.c
@@ -207,8 +207,6 @@ static void init()
         struct itimerspec timerspec;
 
         enable_throttling = 1;
-        // Not necessary because it'll be zeroed by compiler (.bss on x86{,_64})
-        // bzero(effect_is_pending, FFBTOOLS_THROTTLE_BUFFER_SIZE * sizeof(char));
         pthread_spin_init(&pending_effects_lock, PTHREAD_PROCESS_PRIVATE);
 
         throttle_sigev.sigev_notify = SIGEV_THREAD;


### PR DESCRIPTION
setting the environment variable FFBTOOLS_THROTTLING_INTERVAL_MS to the
number of milliseconds desired as the timer interval makes this
configurable at runtime by the user, rather than solely at compile-time.

This also fixes an uncaught error case, where `timer_settime` fails, and ensure that the logging paths are still hit (for debugging purposes), even when an ffb event is throttled.