### PR TITLE
Simplify Makefile and fix warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,17 +18,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-BUILD_DIR ?= ./build
-SRC_DIR ?= ./src
+BUILD_DIR ?= build
+SRC_DIR ?= src
 
 OBJS := $(shell find $(BUILD_DIR) -name *.o 2> /dev/null)
 DEPS := $(OBJS:.o=.d)
 
-INC_DIRS := $(shell find $(SRC_DIR) -type d)
-INC_FLAGS := $(addprefix -I,$(INC_DIRS))
-
-CPPFLAGS ?= $(INC_FLAGS) -MMD -MP -Wall
-LDLIBS ?= -lm
+CFLAGS += -MMD -MP -Wall -Wextra
+LDLIBS += -lm
 
 all: $(BUILD_DIR) \
 	$(BUILD_DIR)/libffbwrapper-i386.so \
@@ -40,21 +37,17 @@ $(BUILD_DIR):
 	mkdir -p $(BUILD_DIR)
 
 $(BUILD_DIR)/libffbwrapper-i386.so: $(SRC_DIR)/ffbwrapper.c
-	$(CC) $(CPPFLAGS) $(CFLAGS) -m32 -fPIC -shared $< -o $@ -lrt -ldl
+	$(CC) $(CFLAGS) -m32 -fPIC -shared $< -o $@ -lrt -ldl
 
 $(BUILD_DIR)/libffbwrapper-x86_64.so: $(SRC_DIR)/ffbwrapper.c
-	$(CC) $(CPPFLAGS) $(CFLAGS) -fPIC -shared $< -o $@ -lrt -ldl
+	$(CC) $(CFLAGS) -fPIC -shared $< -o $@ -lrt -ldl
 
-$(BUILD_DIR)/ffbplay: $(BUILD_DIR)/ffbplay.o
-	$(CC) $(LDFLAGS) -o $@ $< $(LDLIBS)
-
-$(BUILD_DIR)/rawcmd: $(BUILD_DIR)/rawcmd.o
-	$(CC) $(LDFLAGS) -o $@ $< $(LDLIBS)
+$(BUILD_DIR)/%: $(BUILD_DIR)/%.o
 
 $(BUILD_DIR)/%.o: $(SRC_DIR)/%.c
-	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
+	$(CC) $(CFLAGS) -c $< -o $@
 
-.PHONY: directories clean
+.PHONY: clean
 
 clean:
 	$(RM) -r $(BUILD_DIR)

--- a/src/ffbplay.c
+++ b/src/ffbplay.c
@@ -662,7 +662,7 @@ void play_file(const char *file_name, int trace_mode)
 
     while (fgets(line, sizeof(line), file)) {
         if (trace_mode) {
-            printf(line);
+            printf("%s\n", line);
         }
         strtok(line, "\n");
         token = strtok_r(line, " ", &next_token);

--- a/src/ffbplay.c
+++ b/src/ffbplay.c
@@ -208,11 +208,13 @@ char read_option(const char *prompt, const char *options)
     printf("> %s: ", prompt);
 
     do {
-        fgets(input, sizeof(input), stdin);
+        if (!fgets(input, sizeof(input), stdin)) {
+            return '\n';
+        }
 
         if (strlen(input) <= 2) {
             option = input[0];
-            for (int i = 0; i < strlen(options); i++) {
+            for (size_t i = 0; i < strlen(options); i++) {
                 if (option == options[i]) {
                     return option;
                 }
@@ -227,7 +229,9 @@ int read_int(const char *prompt)
 
     printf("> %s: ", prompt);
 
-    fgets(input, sizeof(input), stdin);
+    if (!fgets(input, sizeof(input), stdin)) {
+        return 0;
+    }
 
     return strtol(input, NULL, 0);
 }
@@ -595,6 +599,7 @@ void new_effect(struct ff_effect *effect, char *params)
                         } else if (!strcmp(key, "center")) {
                             effect->u.condition[0].center = nvalue;
                         }
+                        // fall through
                     case FF_DAMPER:
                     case FF_FRICTION:
                     case FF_INERTIA:
@@ -638,13 +643,12 @@ void play_file(const char *file_name, int trace_mode)
     struct timespec now;
     struct timespec start_time;
     struct ff_effect effect;
-    int delta_time;
     char line[1024];
     char *token;
     char *next_token;
     char *prefix;
     char *op;
-    unsigned long time;
+    unsigned long time, delta_time;
     int first = 1;
     int id;
     int count;

--- a/src/ffbwrapper.c
+++ b/src/ffbwrapper.c
@@ -56,8 +56,8 @@ static void init() __attribute__((constructor));
 static void close() __attribute__((destructor));
 
 static int (*_ioctl)(int fd, unsigned long request, char *argp);
-static int dev_major = 0;
-static int dev_minor = 0;
+static unsigned int dev_major = 0;
+static unsigned int dev_minor = 0;
 static int enable_logger = 0;
 static int enable_update_fix = 0;
 static int enable_direction_fix = 0;
@@ -118,6 +118,8 @@ static void send_effect(int id)
 
 static void throttle_function(union sigval value)
 {
+    (void) value;
+
     for (int id = 0; id < FFBTOOLS_THROTTLE_BUFFER_SIZE; id++) {
         if (effect_is_pending[id]) {
             send_effect(id);


### PR DESCRIPTION
This pull request simplifies the Makefile, enables -Wextra, and fixes the subsequent warnings. It also fixes an error preventing ffbplay from compiling with the default CFLAGS on Arch.

Can you verify that the return values on src/ffbplay.c:212 and src/ffbplay.c:233 are correct, and that src/ffbplay.c:601 is supposed to fall through.