### PR TITLE
draft: fix for extreme delay (even with throttling) on logitech g920

### DIFF
--- a/src/ffbwrapper.c
+++ b/src/ffbwrapper.c
@@ -571,22 +571,24 @@ ssize_t write(int fd, const void *buf, size_t num)
                 }
             } else {
                 report("> STOP %u", event->code);
-                effect_is_enabled[event -> code] = false;
+                effect_is_enabled[event->code] = false;
             }
             break;
     }
 
     if (!ignore_write && (!ignore_set_gain || event->code != FF_GAIN)) {
         result = _write(fd, buf, num);
-    } else {
+    }
+    else {
         result = 0;
     }
 
-    report("< %d", result);
-
-    if (enable_features_hack && result != 0 && event->code < FF_MAX_EFFECTS) {
+    if (!ignore_write && enable_features_hack && result != 0 && event->code < FF_MAX_EFFECTS) {
         result = 0;
         report("< %d # features hack", result);
+    }
+    else if (!ignore_write) {
+        report("< %d", result);
     }
 
     return result;


### PR DESCRIPTION
The Logitech G920 uses a HID++ driver that seems to poorly handle `play` commands. The HID++ spec doesn't even seem to have a `play` command so who knows what this is getting translated into without diving into the kernel driver code. Spec: https://opensource.logitech.com/wiki/force_feedback/Logitech_Force_Feedback_Protocol_V1.6.pdf

It seems that the `play` command is only ever required to enable an effect slot, and handling a `play` on the G920 is *extremely* slow. Some games like F1 2022 and Dirt Rally 2.0 seem to spam a huge quantity of `play` commands, causing extreme delay in ffb, even with throttling.

With this patch, and setting `--throttling-time` to 5 (200hz), I no longer see `Force feedback command queue contains x commands, causing substantial delays!` in `dmesg` apart from when `play` commands are sent when ffb is initially configured when starting a game.

I intend to test this patch on a ffb wheel using the other more mainstream driver like the G29 to see how it handles it and what the behavior of `play` is. This enhancement on throttling may require moving into another command line parameter if it interferes with operation on wheels that don't use HID++.

I would appreciate some review from someone with more than 12 hours experience in force feedback magic :)