### PR TITLE
Add `--ignore-autocenter` option to ffbwrap

### DIFF
--- a/bin/ffbwrap
+++ b/bin/ffbwrap
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-OPTIONS=$(getopt --long 'logger:,update-fix,direction-fix,duration-fix,features-hack,force-inversion,ignore-set-gain,offset-fix,throttling,throttling-time:' -n "$0" -- "" "$@")
+OPTIONS=$(getopt --long 'logger:,update-fix,direction-fix,duration-fix,features-hack,force-inversion,ignore-set-gain,ignore-autocenter,offset-fix,throttling,throttling-time:' -n "$0" -- "" "$@")
 
 if [ $? -ne 0 ]; then
 	exit 1
@@ -80,6 +80,11 @@ while true; do
             shift
             continue
             ;;
+        '--ignore-autocenter')
+            FFBTOOLS_IGNORE_AUTOCENTER=1
+            shift
+            continue
+            ;;
         '--offset-fix')
             FFBTOOLS_OFFSET_FIX=1
             shift
@@ -119,12 +124,12 @@ COMMAND="$1"
 shift
 
 if [ -z "${FFBTOOLS_DEV_MAJOR}" -o -z "${FFBTOOLS_DEV_MINOR}" -o -z "${COMMAND}" ]; then
-    echo "Usage: $0 [--logger=logfile] [--update-fix] [--direction-fix] [--duration-fix] [--features-hack] [--force-inversion] [--ignore-set-gain] [--offset-fix] [--throttling] [--throttling-time=N] <device> -- <command>"
+    echo "Usage: $0 [--logger=logfile] [--update-fix] [--direction-fix] [--duration-fix] [--features-hack] [--force-inversion] [--ignore-set-gain] [--ignore-autocenter] [--offset-fix] [--throttling] [--throttling-time=N] <device> -- <command>"
     exit 1
 fi
 
 FFBTOOLS_DEVICE_NAME="$(eval $(udevadm info -q property -x "${DEVICE_FILE}") && echo "${ID_VENDOR} ${ID_MODEL//_/ }")"
 
-export LD_PRELOAD FFBTOOLS_DEVICE_NAME FFBTOOLS_DEV_MAJOR FFBTOOLS_DEV_MINOR FFBTOOLS_LOGGER FFBTOOLS_LOG_FILE FFBTOOLS_UPDATE_FIX FFBTOOLS_DIRECTION_FIX FFBTOOLS_DURATION_FIX FFBTOOLS_FEATURES_HACK FFBTOOLS_FORCE_INVERSION FFBTOOLS_IGNORE_SET_GAIN FFBTOOLS_OFFSET_FIX FFBTOOLS_THROTTLING
+export LD_PRELOAD FFBTOOLS_DEVICE_NAME FFBTOOLS_DEV_MAJOR FFBTOOLS_DEV_MINOR FFBTOOLS_LOGGER FFBTOOLS_LOG_FILE FFBTOOLS_UPDATE_FIX FFBTOOLS_DIRECTION_FIX FFBTOOLS_DURATION_FIX FFBTOOLS_FEATURES_HACK FFBTOOLS_FORCE_INVERSION FFBTOOLS_IGNORE_SET_GAIN FFBTOOLS_IGNORE_AUTOCENTER FFBTOOLS_OFFSET_FIX FFBTOOLS_THROTTLING
 
 "${COMMAND}" "$@"

--- a/docs/ffbwrap.md
+++ b/docs/ffbwrap.md
@@ -35,6 +35,8 @@ One or more of the following options can be used:
   together with `--direction-fix`.
 
   `--ignore-set-gain`: Ignore any attempt to change the global FF gain.
+  
+  `--ignore-autocenter`: Ignore any attempt to change autocenter strength.
 
   `--offset-fix`: Proton sets `offset` and `phase` to incorrect values. This
   option fixes it.


### PR DESCRIPTION
This allows to ignore any change to the global autocentering effect.

In recent Wine AUTOCENTER effect is become available and now on every DEVICE_RESET command autocenter is set to 100 and resets back to 0 if autocenter is disabled in the device. But Wine can't get current autocenter gain from the device as methods for that just don't exist on SDL/udev, so it enables autocenter by default.
